### PR TITLE
feat: add features section with cards

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import { Features } from '@/components/sections/features'
 import { ArrowRight, ArrowDown, Sparkles, Zap, Users, MessageSquare, Palette, Code, BarChart3, Megaphone, Brain, Target, Star, ExternalLink, Github, Linkedin, Mail, Calendar, ChevronRight } from 'lucide-react'
 
 export default function LandingPage() {
@@ -103,6 +104,8 @@ export default function LandingPage() {
           </div>
         </div>
       </section>
+
+      <Features />
 
       {/* CTA Final */}
       <section className="py-20 px-4 bg-muted/30">

--- a/components/sections/features.tsx
+++ b/components/sections/features.tsx
@@ -1,0 +1,48 @@
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Brain, Zap, Shield, Sparkles } from "lucide-react"
+
+const features = [
+  {
+    icon: Brain,
+    title: "Analyse prédictive",
+    description: "Transformez vos données en décisions éclairées.",
+  },
+  {
+    icon: Zap,
+    title: "Automatisation rapide",
+    description: "Optimisez vos workflows grâce à l'IA.",
+  },
+  {
+    icon: Shield,
+    title: "Sécurité avancée",
+    description: "Protégez vos informations sensibles.",
+  },
+  {
+    icon: Sparkles,
+    title: "Interface intuitive",
+    description: "Une expérience fluide et moderne.",
+  },
+]
+
+export function Features() {
+  return (
+    <section className="py-20 px-4">
+      <div className="container mx-auto max-w-6xl">
+        <h2 className="text-3xl lg:text-4xl font-bold text-center mb-12">
+          Fonctionnalités clés
+        </h2>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          {features.map((feature, idx) => (
+            <Card key={idx} className="text-center">
+              <CardHeader className="items-center">
+                <feature.icon className="h-10 w-10 mb-4 text-primary" />
+                <CardTitle>{feature.title}</CardTitle>
+                <CardDescription>{feature.description}</CardDescription>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,62 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+      {...props}
+    />
+  )
+)
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  )
+)
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3
+      ref={ref}
+      className={cn("text-2xl font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  )
+)
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  )
+)
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  )
+)
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  )
+)
+CardFooter.displayName = "CardFooter"
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+}


### PR DESCRIPTION
## Summary
- add shadcn-style Card component
- create features section with Lucide icons
- integrate features section into landing page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: interactive ESLint configuration)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2f533d87883329ad854f93f31d5e8